### PR TITLE
Add support for ephemeral NSURLSessionConfiguration

### DIFF
--- a/Sources/Objc/NSURLSessionConfiguration+Wormholy.m
+++ b/Sources/Objc/NSURLSessionConfiguration+Wormholy.m
@@ -12,10 +12,19 @@
 
 typedef NSURLSessionConfiguration*(*SessionConfigConstructor)(id,SEL);
 static SessionConfigConstructor orig_defaultSessionConfiguration;
+static SessionConfigConstructor orig_ephemeralSessionConfiguration;
 
 static NSURLSessionConfiguration* Wormholy_defaultSessionConfiguration(id self, SEL _cmd)
 {
     NSURLSessionConfiguration* config = orig_defaultSessionConfiguration(self,_cmd); // call original method
+    
+    [Wormholy enable:YES sessionConfiguration:config];
+    return config;
+}
+
+static NSURLSessionConfiguration* Wormholy_ephemeralSessionConfiguration(id self, SEL _cmd)
+{
+    NSURLSessionConfiguration* config = orig_ephemeralSessionConfiguration(self,_cmd); // call original method
     
     [Wormholy enable:YES sessionConfiguration:config];
     return config;
@@ -26,9 +35,14 @@ static NSURLSessionConfiguration* Wormholy_defaultSessionConfiguration(id self, 
 +(void)load
 {
     orig_defaultSessionConfiguration = (SessionConfigConstructor)WormholyReplaceMethod(@selector(defaultSessionConfiguration),
-                                                                                          (IMP)Wormholy_defaultSessionConfiguration,
-                                                                                          [NSURLSessionConfiguration class],
-                                                                                          YES);
+                                                                                       (IMP)Wormholy_defaultSessionConfiguration,
+                                                                                       [NSURLSessionConfiguration class],
+                                                                                       YES);
+    
+    orig_ephemeralSessionConfiguration = (SessionConfigConstructor)WormholyReplaceMethod(@selector(ephemeralSessionConfiguration),
+                                                                                         (IMP)Wormholy_ephemeralSessionConfiguration,
+                                                                                         [NSURLSessionConfiguration class],
+                                                                                         YES);
 }
 
 


### PR DESCRIPTION
[Siesta](https://bustoutsolutions.github.io/siesta/) uses an ephemeral `NSURLSessionConfiguration` by default, so its traffic wasn't showing up when I installed Wormholy.