### PR TITLE
Programmatically enable/disable the shake gesture

### DIFF
--- a/Sources/Subclasses/WHBaseViewController.swift
+++ b/Sources/Subclasses/WHBaseViewController.swift
@@ -67,10 +67,7 @@ extension UIViewController{
     
     open override func motionBegan(_ motion: UIEventSubtype, with event: UIEvent?) {
         //Shake shake
-        if motion == .motionShake{
-            guard ProcessInfo.processInfo.environment["WORMHOLY_SHAKE_ENABLED"] != "NO" else {
-                return
-            }
+        if motion == .motionShake && Wormholy.shakeEnabled {
             NotificationCenter.default.post(name: fireWormholy, object: nil)
         }
     }

--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -73,4 +73,24 @@ public class Wormholy: NSObject
             UIViewController.currentViewController()?.present(initialVC, animated: true, completion: nil)
         }
     }
+    
+    public static var shakeEnabled: Bool = {
+        let key = "WORMHOLY_SHAKE_ENABLED"
+        
+        if let environmentVariable = ProcessInfo.processInfo.environment[key] {
+            return environmentVariable != "NO"
+        }
+        
+        let arguments = UserDefaults.standard.volatileDomain(forName: UserDefaults.argumentDomain)
+        if let arg = arguments[key] {
+            switch arg {
+            case let boolean as Bool: return boolean
+            case let string as NSString: return string.boolValue
+            case let number as NSNumber: return number.boolValue
+            default: break
+            }
+        }
+        
+        return false
+    }()
 }


### PR DESCRIPTION
Adds a public property on the `Wormholy` class called `shakeEnabled`.

If untouched, this value will default to the environment variable setting, fall back to looking the command-line arguments passed to the program, and otherwise default to `false`.

However, at any time you can do `Wormholy.shakeEnabled = true // or false` to enable or disable the shake gesture. If you set this value before a shake has occurred, then the default logic is never executed (in accordance with how lazy properties work).

Addresses #12 