### PR TITLE
Support Swfit Static Library

### DIFF
--- a/Sources/Objc/NSURLSessionConfiguration+Wormholy.m
+++ b/Sources/Objc/NSURLSessionConfiguration+Wormholy.m
@@ -8,7 +8,11 @@
 
 #import "NSURLSessionConfiguration+Wormholy.h"
 #import "WormholyMethodSwizzling.h"
+#if __has_include(<Wormholy/Wormholy-Swift.h>)
 #import <Wormholy/Wormholy-Swift.h>
+#else
+#import "Wormholy-Swift.h"
+#endif
 
 typedef NSURLSessionConfiguration*(*SessionConfigConstructor)(id,SEL);
 static SessionConfigConstructor orig_defaultSessionConfiguration;

--- a/Sources/Objc/Wormholy+Foo.m
+++ b/Sources/Objc/Wormholy+Foo.m
@@ -6,7 +6,11 @@
 //  Copyright © 2018 Wormholy. All rights reserved.
 //
 
+#if __has_include(<Wormholy/Wormholy-Swift.h>)
 #import <Wormholy/Wormholy-Swift.h>
+#else
+#import "Wormholy-Swift.h"
+#endif
 
 @implementation Wormholy (private)
 + (void)load { [self swiftyLoad];}


### PR DESCRIPTION
When use  cocoapods swift static library(http://blog.cocoapods.org/CocoaPods-1.5.0/) ,there has no more <Wormholy/Wormholy-Swift.h>.
use __has_include to detect if we can import Wormholy by dynamic framework header, or just import it by classical static header.