### PR TITLE
ShakeEnabled property set to true by default

### DIFF
--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -91,6 +91,6 @@ public class Wormholy: NSObject
             }
         }
         
-        return false
+        return true
     }()
 }


### PR DESCRIPTION
ShakeEnabled property set to true by default to avoid having to set this property to true manually