### PR TITLE
Added possibility to clear requests

### DIFF
--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -27,4 +27,8 @@ class Storage: NSObject {
             requests.insert(request!, at: 0)
         }
     }
+
+    func clearRequests() {
+        requests = []
+    }
 }

--- a/Sources/UI/RequestsViewController.swift
+++ b/Sources/UI/RequestsViewController.swift
@@ -20,7 +20,8 @@ class RequestsViewController: WHBaseViewController {
         addSearchController()
         
         navigationItem.rightBarButtonItems = [UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))]
-        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: "Clear", style: .plain, target: self, action: #selector(clearRequests))
+
         collectionView?.register(UINib(nibName: "RequestCell", bundle:WHBundle.getBundle()), forCellWithReuseIdentifier: "RequestCell")
         
         filteredRequests = Storage.shared.requests
@@ -75,6 +76,12 @@ class RequestsViewController: WHBaseViewController {
         return Storage.shared.requests.filter { (request) -> Bool in
             return request.url.range(of: text!, options: .caseInsensitive) != nil ? true : false
         }
+    }
+
+    @objc private func clearRequests() {
+        Storage.shared.clearRequests()
+        filteredRequests = Storage.shared.requests
+        collectionView.reloadData()
     }
     
     // MARK: - Navigation


### PR DESCRIPTION
Added clear button on requests screen which clears all requests both from storage and from `RequestsViewController`.
Fixes #28 