### PR TITLE
Added computed var to obtain the main View Controller

### DIFF
--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -74,6 +74,11 @@ public class Wormholy: NSObject
         }
     }
     
+    @objc public static var wormholyFlow: UIViewController? {
+        let storyboard = UIStoryboard(name: "Flow", bundle: WHBundle.getBundle())
+        return storyboard.instantiateInitialViewController()
+    }
+    
     @objc public static var shakeEnabled: Bool = {
         let key = "WORMHOLY_SHAKE_ENABLED"
         


### PR DESCRIPTION
Added a new public var in order to get only the main view controller.

- Allows to integrate Wormholy flow above other view controllers. 