### PR TITLE
Fixed crash caused when UIAlertController with actionSheet style is presented on iPad

### DIFF
--- a/Sources/UI/RequestsViewController.swift
+++ b/Sources/UI/RequestsViewController.swift
@@ -91,6 +91,9 @@ class RequestsViewController: WHBaseViewController {
         })
         ac.addAction(UIAlertAction(title: "Close", style: .cancel) { (action) in
         })
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            ac.popoverPresentationController?.barButtonItem = navigationItem.leftBarButtonItem
+        }
         present(ac, animated: true, completion: nil)
     }
     


### PR DESCRIPTION
Fix for iPad crash when 'More' navigation button is touched