### PR TITLE
Fix a memory leak in CustomHTTPProtocol.

### DIFF
--- a/Sources/CustomHTTPProtocol.swift
+++ b/Sources/CustomHTTPProtocol.swift
@@ -54,6 +54,7 @@ public class CustomHTTPProtocol: URLProtocol {
             currentRequest?.duration = fabs(startDate.timeIntervalSinceNow) * 1000 //Find elapsed time and convert to milliseconds
         }
         Storage.shared.saveRequest(request: currentRequest)
+        session.invalidateAndCancel()
     }
     
     private func body(from request: URLRequest) -> Data? {


### PR DESCRIPTION
There is currently a 5-node retain cycle when Wormholy is presented, primarily because `URLSession` has a strong delegate reference to `CustomHTTPProtocol`, which in turn has a strong reference back to the `URLSession`.

Break the chain when `stopLoading()` is called, by invalidating the `URLSession` and so it breaks its strong delegate reference.