### PR TITLE
Allow other UIResponders to respond to the shake event

### DIFF
--- a/Sources/Subclasses/WHBaseViewController.swift
+++ b/Sources/Subclasses/WHBaseViewController.swift
@@ -70,5 +70,7 @@ extension UIViewController{
         if motion == .motionShake && Wormholy.shakeEnabled {
             NotificationCenter.default.post(name: fireWormholy, object: nil)
         }
+        
+        next?.motionBegan(motion, with: event)
     }
 }


### PR DESCRIPTION
If other components in an app respond to the shake and are further up the responder chain from `UIViewController` they won't receive the events as they are consumed within the `UIViewController` extension in `WHBaseViewController`. Passing the event up allows those responders to handle the event as required.