### PR TITLE
Added ability to blacklist hosts from being recorded

### DIFF
--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -11,6 +11,11 @@ import UIKit
 
 public class Wormholy: NSObject
 {
+    @objc public static var blacklistedHosts: [String] {
+        get { return CustomHTTPProtocol.blacklistedHosts }
+        set { CustomHTTPProtocol.blacklistedHosts = newValue }
+    }
+
     @objc public static func swiftyLoad() {
         NotificationCenter.default.addObserver(forName: fireWormholy, object: nil, queue: nil) { (notification) in
             Wormholy.presentWormholyFlow()

--- a/WormholyDemo/ViewController.swift
+++ b/WormholyDemo/ViewController.swift
@@ -8,11 +8,12 @@
 
 import UIKit
 import Foundation
-
+import Wormholy
 class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         if #available(iOS 10.0, *) {
             let timer = Timer.scheduledTimer(withTimeInterval: 8, repeats: true) { (timer) in
                 DataFetcher.sharedInstance.getPost(id: Utils.random(max: 128), completion: {


### PR DESCRIPTION
There are cases where certain endpoints can get hit a lot, causing a lot of chattiness, like with analytics endpoints. This enhancement would allow for certain hosts to be blacklisted and not be recorded.