### PR TITLE
Rename `blacklistedHosts` to `ignoredHosts`

### DIFF
--- a/Sources/CustomHTTPProtocol.swift
+++ b/Sources/CustomHTTPProtocol.swift
@@ -9,7 +9,16 @@
 import Foundation
 
 public class CustomHTTPProtocol: URLProtocol {
-    static var blacklistedHosts = [String]()
+    static var ignoredHosts = [String]()
+    @available(*, deprecated, renamed: "ignoredHosts")
+    static var blacklistedHosts: [String] {
+        get {
+            return ignoredHosts
+        }
+        set {
+            ignoredHosts = newValue
+        }
+    }
 
     struct Constants {
         static let RequestHandledKey = "URLProtocolRequestHandled"
@@ -80,7 +89,7 @@ public class CustomHTTPProtocol: URLProtocol {
     private class func shouldHandleRequest(_ request: URLRequest) -> Bool {
         guard let host = request.url?.host else { return false }
 
-        return CustomHTTPProtocol.blacklistedHosts.filter({ host.hasSuffix($0) }).isEmpty
+        return CustomHTTPProtocol.ignoredHosts.filter({ host.hasSuffix($0) }).isEmpty
     }
     
     deinit {

--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -11,9 +11,15 @@ import UIKit
 
 public class Wormholy: NSObject
 {
+    @available(*, deprecated, renamed: "ignoredHosts")
     @objc public static var blacklistedHosts: [String] {
-        get { return CustomHTTPProtocol.blacklistedHosts }
-        set { CustomHTTPProtocol.blacklistedHosts = newValue }
+        get { return CustomHTTPProtocol.ignoredHosts }
+        set { CustomHTTPProtocol.ignoredHosts = newValue }
+    }
+
+    @objc public static var ignoredHosts: [String] {
+        get { return CustomHTTPProtocol.ignoredHosts }
+        set { CustomHTTPProtocol.ignoredHosts = newValue }
     }
 
     @objc public static func swiftyLoad() {


### PR DESCRIPTION
Hi!
I'd like to suggest that we rename `blacklistedHosts` to `ignoredHosts`. I think the new name would express the intent of the config better, plus the history of the term "blacklist" has potential bad connotations. I think the commentary from dhh on this rails issue summarizes it nicely: https://github.com/rails/rails/issues/33677

-Al