### PR TITLE
Fixed an infinite loop blocking bug related to multipart requests

### DIFF
--- a/Sources/CustomHTTPProtocol.swift
+++ b/Sources/CustomHTTPProtocol.swift
@@ -62,17 +62,7 @@ public class CustomHTTPProtocol: URLProtocol {
     }
     
     private func body(from request: URLRequest) -> Data? {
-        return request.httpBody ?? request.httpBodyStream.flatMap { stream in
-            let data = NSMutableData()
-            stream.open()
-            while stream.hasBytesAvailable {
-                var buffer = [UInt8](repeating: 0, count: 1024)
-                let length = stream.read(&buffer, maxLength: buffer.count)
-                data.append(buffer, length: length)
-            }
-            stream.close()
-            return data as Data
-        }
+        return request.httpBody
     }
 
     /// Inspects the request to see if the host has not been blacklisted and can be handled by this URL protocol.

--- a/Wormholy.podspec
+++ b/Wormholy.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Wormholy"
-  s.version      = "1.6.2"
+  s.version      = "1.6.3"
   s.summary      = "Network debugging made easy"
   s.description  = <<-DESC
     Start debugging iOS network calls like a wizard, without extra code! Wormholy makes debugging quick and reliable.


### PR DESCRIPTION
#38
The problem was an infinite while loop that didn't end. 
When multipart request had begun, loop started and blocked all further requests. 