### PR TITLE
Fix keyboard content inset bug

### DIFF
--- a/Sources/UI/RequestsViewController.swift
+++ b/Sources/UI/RequestsViewController.swift
@@ -31,6 +31,11 @@ class RequestsViewController: WHBaseViewController {
                 self?.collectionView.reloadData()
             }
         }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)),
+                                               name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)),
+                    name: UIResponder.keyboardWillHideNotification, object: nil)
         
     }
     
@@ -130,6 +135,24 @@ class RequestsViewController: WHBaseViewController {
     deinit {
         NotificationCenter.default.removeObserver(self, name: newRequestNotification, object: nil)
     }
+
+    // MARK: - Keyboard
+    @objc
+    func keyboardWillShow(_ notification: NSNotification) {
+        let userInfo = notification.userInfo
+        guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else { return }
+
+        let contentInset = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardFrame.height, right: 0.0)
+        collectionView.contentInset = contentInset
+        collectionView.scrollIndicatorInsets = contentInset
+    }
+
+    @objc
+    func keyboardWillHide(_ notification: NSNotification) {
+        collectionView.contentInset = .zero
+        collectionView.scrollIndicatorInsets = .zero
+    }
+
 }
 
 extension RequestsViewController: UICollectionViewDataSource{


### PR DESCRIPTION
This fixes the issue where when filtering the list of requests you couldn't see the last one because it was obscured by the keyboard:
![keyboard](https://user-images.githubusercontent.com/1180883/106363063-38d5a580-62f4-11eb-88c8-5f95b5c61866.gif)
