### PR TITLE
Add option for a default filter

### DIFF
--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -13,6 +13,8 @@ open class Storage: NSObject {
     public static let shared: Storage = Storage()
   
     public static var limit: NSNumber? = nil
+
+    public static var defaultFilter: String? = nil
     
     open var requests: [RequestModel] = []
     

--- a/Sources/UI/RequestsViewController.swift
+++ b/Sources/UI/RequestsViewController.swift
@@ -61,6 +61,9 @@ class RequestsViewController: WHBaseViewController {
             // Fallback
         }
         searchController?.searchBar.placeholder = "Search URL"
+        if let filter = Storage.defaultFilter {
+            searchController?.searchBar.text = filter
+        }
         if #available(iOS 11.0, *) {
             navigationItem.searchController = searchController
         } else {

--- a/Sources/Wormholy.swift
+++ b/Sources/Wormholy.swift
@@ -31,6 +31,13 @@ public class Wormholy: NSObject
         set { Storage.limit = newValue }
     }
 
+    /// Default filter for the search box
+    ///
+    @objc public static var defaultFilter: String? {
+        get { Storage.defaultFilter }
+        set { Storage.defaultFilter = newValue }
+    }
+
     @objc public static func swiftyLoad() {
         NotificationCenter.default.addObserver(forName: fireWormholy, object: nil, queue: nil) { (notification) in
             Wormholy.presentWormholyFlow()


### PR DESCRIPTION
Adds the option to have a default filter configured, for example you could set it to `api.mycompany.com` so you don't see noisy requests from 3rd party libraries.