### PR TITLE
Fixed: swift compiler warning against deprecated 'class'

### DIFF
--- a/Sources/Utils/SwiftySelfAwareHelper.swift
+++ b/Sources/Utils/SwiftySelfAwareHelper.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-protocol SelfAware: class {
+protocol SelfAware: AnyObject {
     static func awake()
 }
 


### PR DESCRIPTION
Nothing about performance but keep an up-to-date codebase:)