### PR TITLE
Migrate to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,63 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "Wormholy",
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "Wormholy",
-            targets: ["Wormholy"]),
+    platforms:[
+        .iOS(.v11)
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+    products: [
+         .library(
+             name: "Wormholy",
+             targets: ["Wormholy"]
+         ),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "_WormholySwift",
+            path: "Sources",
+            exclude: [
+                "Objc",
+                "spm",
+                "module.modulemap"
+            ],
+            resources: [
+                .copy("Models/Postman/Postman_demo_collection.json"),
+                .process("Support Files/Assets.xcassets"),
+                .copy("UI/Cells/ActionableTableViewCell.xib"),
+                .copy("UI/Cells/RequestCell.xib"),
+                .copy("UI/Cells/TextTableViewCell.xib"),
+                .copy("UI/Sections/RequestTitleSectionView.xib"),
+                .copy("UI/Flow.storyboard"),
+            ],
+            cSettings: [
+                .define("SWIFT_PACKAGE")
+            ]
+        ),
+
+        .target(
+            name: "_WormholyObjC",
+            dependencies: [
+                "_WormholySwift"
+            ],
+            path: "Sources/Objc",
+            cSettings: [
+                .define("SWIFT_PACKAGE")
+            ]
+        ),
+
         .target(
             name: "Wormholy",
-            dependencies: []),
-        .testTarget(
-            name: "WormholyTests",
-            dependencies: ["Wormholy"]),
+            dependencies: [
+                "_WormholySwift",
+                "_WormholyObjC"
+            ],
+            path: "Sources/spm/AggregatedModule",
+            cSettings: [
+                .define("SWIFT_PACKAGE")
+            ]
+        ),
     ]
 )

--- a/Sources/Objc/NSURLSessionConfiguration+Wormholy.m
+++ b/Sources/Objc/NSURLSessionConfiguration+Wormholy.m
@@ -8,11 +8,15 @@
 
 #import "NSURLSessionConfiguration+Wormholy.h"
 #import "WormholyMethodSwizzling.h"
+#if SWIFT_PACKAGE
+@import _WormholySwift;
+#else
 #if __has_include(<Wormholy/Wormholy-Swift.h>)
 #import <Wormholy/Wormholy-Swift.h>
 #else
 #import "Wormholy-Swift.h"
-#endif
+#endif // #if __has_include(<Wormholy/Wormholy-Swift.h>)
+#endif // #if SWIFT_PACKAGE
 
 typedef NSURLSessionConfiguration*(*SessionConfigConstructor)(id,SEL);
 static SessionConfigConstructor orig_defaultSessionConfiguration;

--- a/Sources/Objc/Wormholy.h
+++ b/Sources/Objc/Wormholy.h
@@ -17,7 +17,6 @@
 #endif
 #endif
 
-
 #import "NSURLSessionConfiguration+Wormholy.h"
 #import "WormholyMethodSwizzling.h"
 

--- a/Sources/Objc/include/module.modulemap
+++ b/Sources/Objc/include/module.modulemap
@@ -1,0 +1,8 @@
+// This is the modulemap for the ObjC SPM target **ONLY**.
+
+module Wormholy {
+    umbrella header "../Wormholy.h"
+
+    export *
+    module * { export * }
+}

--- a/Sources/Utils/ShareUtils.swift
+++ b/Sources/Utils/ShareUtils.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 final class ShareUtils {
 

--- a/Sources/module.modulemap
+++ b/Sources/module.modulemap
@@ -1,6 +1,6 @@
 framework module Wormholy {
     umbrella header "Wormholy.h"
-    
+
     export *
     module * { export * }
 }

--- a/Sources/spm/AggregatedModule/Placeholder.swift
+++ b/Sources/spm/AggregatedModule/Placeholder.swift
@@ -1,0 +1,1 @@
+@_exported import _WormholySwift

--- a/Wormholy.podspec
+++ b/Wormholy.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "11.0"
   s.source       = { :git => "https://github.com/pmusolino/Wormholy.git", :tag => s.version.to_s }
   s.source_files  = "Sources/**/*.{swift,h,m}"
+  s.exclude_files = "Sources/spm"
   s.swift_version = "5.0"
   s.public_header_files = "Sources/**/*.h"
   s.resource_bundles = {

--- a/Wormholy.xcodeproj/project.pbxproj
+++ b/Wormholy.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4025634F2BCD49E700694AEB /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		45087189207E59FE00EE2D31 /* WormholyDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WormholyDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4508718B207E59FF00EE2D31 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4508718D207E59FF00EE2D31 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -168,6 +169,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		402563472BCD3F9D00694AEB /* include */ = {
+			isa = PBXGroup;
+			children = (
+				45C51A1620A1FDBC006933CE /* module.modulemap */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
 		4508718A207E59FF00EE2D31 /* WormholyDemo */ = {
 			isa = PBXGroup;
 			children = (
@@ -280,6 +289,8 @@
 		455818CA207D647900D2F954 /* Objc */ = {
 			isa = PBXGroup;
 			children = (
+				45C51A1720A20B38006933CE /* Wormholy.h */,
+				402563472BCD3F9D00694AEB /* include */,
 				455818D3207D64A800D2F954 /* NSURLSessionConfiguration+Wormholy.h */,
 				455818D0207D64A800D2F954 /* NSURLSessionConfiguration+Wormholy.m */,
 				455818D4207D64A800D2F954 /* WormholyMethodSwizzling.h */,
@@ -342,10 +353,9 @@
 			isa = PBXGroup;
 			children = (
 				8933C7841EB5B820000D00A4 /* Wormholy.swift */,
+				4025634F2BCD49E700694AEB /* module.modulemap */,
 				455818C1207D61A100D2F954 /* CustomHTTPProtocol.swift */,
 				455818C2207D61A100D2F954 /* Storage.swift */,
-				45C51A1620A1FDBC006933CE /* module.modulemap */,
-				45C51A1720A20B38006933CE /* Wormholy.h */,
 				451C9E532080E592002A34BC /* UI */,
 				451C9E562080E5F0002A34BC /* Subclasses */,
 				455818CA207D647900D2F954 /* Objc */,


### PR DESCRIPTION
- Migrated to SPM
- Introduced WormholySwift as a wrapper target for Swift files as SPM doesn't support multi-lang modules
- Cleaned up and update demo
- Removed configs as unnecessary
- Updated podfile

Resolves #112, #139 