### PR TITLE
fix: `keyWindow` deprecation warning

### DIFF
--- a/Sources/Subclasses/WHBaseViewController.swift
+++ b/Sources/Subclasses/WHBaseViewController.swift
@@ -40,7 +40,7 @@ class WHBaseViewController: UIViewController {
 }
 
 extension UIViewController{
-    static func currentViewController(_ viewController: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
+    static func currentViewController(_ viewController: UIViewController? = UIApplication.shared.windows.filter(\.isKeyWindow).first?.rootViewController) -> UIViewController? {
         guard let viewController = viewController else { return nil }
         
         if let viewController = viewController as? UINavigationController {


### PR DESCRIPTION
The current method to select the rootViewController from the key window was deprecated as of iOS 13.
This PR uses the non-deprecated approach.