### PR TITLE
fix: Search Result on Response Body and Request Body screen not visible on darkmode

### DIFF
--- a/Sources/Subclasses/WHTextView.swift
+++ b/Sources/Subclasses/WHTextView.swift
@@ -19,6 +19,9 @@ extension WHTextView {
         
         let attributed = NSMutableAttributedString(string: textViewText)
         attributed.addAttribute(.font, value: font, range: NSRange(location: 0, length: self.attributedText.length))
+        if #available(iOS 13.0, *) {
+            attributed.addAttribute(.foregroundColor, value: UIColor.label, range: NSRange(location: 0, length: self.attributedText.length))
+        }
         
         do {
             let regex = try NSRegularExpression(pattern: keywordSearch, options: .caseInsensitive)


### PR DESCRIPTION
### Summary
On darkmode enabled, when searching a keyword inside Request Body or Response Body, the screen shows matched (highlighted) text only. The remaining text appear black, blend with its background color, so it can't be read.
The issue was raised on https://github.com/pmusolino/Wormholy/issues/128

### Steps to reproduce
* Run in darkmode
* Shake to trigger Wormholy interface
* Tap one of API listed there
* Tap `View Body` inside `Request Body` or `Response Body` section
* Tap search button, search any keyword contained in request/response body

### What is the current *bug* behavior?
The screen shows highlighted matched text only. The remaining are black, blends with its background color.

### What is the expected *correct* behavior?
The screen should show remaining non-matched text also.

### Root Cause
On `WHTextView` inside `highlight(text:with:font:highlightedFont:) -> [NSTextCheckingResult]` method, it adds attributes only to the highlighted text. But for the default text (non-matched) attribute wasn't set yet. That's why its text color was black as same as its background color.

### How to solve ?
Set attributes `.foregroundColor` to `UIColor.label` as default attribute to the text. Please note that `UIColor.label` is only available for iOS 13 or above, since dark mode feature was first introduced in that iOS version.

### Relevant logs and/or screenshots
<!-- Paste any relevant logs - please use code blocks (```) to format console output, logs, and code
 as it's tough to read otherwise. -->
| Before | After |
| ------ | ------ |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-08 at 10 32 39](https://user-images.githubusercontent.com/50400034/206353545-2d971bd7-f351-438b-9be3-5a06ce21c792.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-12-08 at 10 33 17](https://user-images.githubusercontent.com/50400034/206353580-252126f1-ee33-423e-a36c-8ba92dc4864a.png) |