### PR TITLE
Added auto font sizing for RequestCell

### DIFF
--- a/Sources/UI/Cells/RequestCell.swift
+++ b/Sources/UI/Cells/RequestCell.swift
@@ -45,6 +45,9 @@ class RequestCell: UICollectionViewCell {
             codeLabel.textColor = Colors.HTTPCode.Generic
         }
         urlLabel.text = request?.url
+        urlLabel.adjustsFontSizeToFitWidth = true
+        urlLabel.minimumScaleFactor = 0.5
+        urlLabel.numberOfLines = 0
         durationLabel.text = request?.duration?.formattedMilliseconds() ?? ""
     }
 }


### PR DESCRIPTION
### Problem
With long URLs, requestCell's urlLabel truncating.

### Solution
Enabling urllabel's adjustFontSizeToFitWidth property and setting a minimum scale, we can see the full URL on RequestCell