### PR TITLE
Fix BodyDetailView navigation title for request vs response body

### DIFF
--- a/Sources/WormholySwift/UI/BodyDetailView.swift
+++ b/Sources/WormholySwift/UI/BodyDetailView.swift
@@ -14,9 +14,11 @@ internal struct BodyDetailView: View {
     @State private var currentPosition: Int = 0
     @State private var isShareSheetPresented: Bool = false
     private let dataBody: String
-    
-    init(dataBody: Data) {
+    private let title: String
+
+    init(dataBody: Data, title: String) {
         self.dataBody = String(data: dataBody, encoding: .utf8)?.prettyPrintedJSON ?? "No body available"
+        self.title = title
     }
     
     var body: some View {
@@ -59,7 +61,7 @@ internal struct BodyDetailView: View {
             .padding()
             .background(Color(UIColor.systemBackground).opacity(0.9))
         }
-        .navigationTitle("Response Body")
+        .navigationTitle(title)
         .navigationBarItems(trailing: Button(action: {
             isShareSheetPresented = true
         }) {
@@ -104,7 +106,7 @@ struct BodyDetailView_Previews: PreviewProvider {
         }
         """.data(using: .utf8)
         
-        return BodyDetailView(dataBody: sampleData!)
+        return BodyDetailView(dataBody: sampleData!, title: "Response Body")
             .previewDisplayName("Body Detail View")
     }
 }

--- a/Sources/WormholySwift/UI/RequestDetailView.swift
+++ b/Sources/WormholySwift/UI/RequestDetailView.swift
@@ -33,7 +33,7 @@ internal struct RequestDetailView: View {
             Section("Request Body") {
                 if let httpBody = request.httpBody {
                     NavigationLink("View body") {
-                        BodyDetailView(dataBody: httpBody)
+                        BodyDetailView(dataBody: httpBody, title: "Request Body")
                     }
                 } else {
                     Text("No body available")
@@ -51,7 +51,7 @@ internal struct RequestDetailView: View {
             Section("Response Body") {
                 if let dataResponse = request.dataResponse {
                     NavigationLink("View body") {
-                        BodyDetailView(dataBody: dataResponse)
+                        BodyDetailView(dataBody: dataResponse, title: "Response Body")
                     }
                 } else {
                     Text("No body available")


### PR DESCRIPTION
## Summary

- Parameterize the `BodyDetailView` navigation title so it correctly displays **"Request Body"** or **"Response Body"** depending on context
- Previously the title was hardcoded to "Response Body", which was incorrect when viewing a request body

Closes #161

## Test plan

- [x] Build succeeds with no errors
- [x] Open WormholyDemo → trigger network requests → tap a request
- [x] Tap "View body" in the **Request Body** section → confirm title shows **"Request Body"**
- [x] Tap "View body" in the **Response Body** section → confirm title shows **"Response Body"**

🤖 Generated with [Claude Code](https://claude.com/claude-code)